### PR TITLE
Put constraints on number of assets in export chunk. Enforce limit of 30 MB on data uploaded to sentinel.

### DIFF
--- a/Solutions/TenableIO/Data Connectors/TenableExportsOrchestrator/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableExportsOrchestrator/__init__.py
@@ -28,8 +28,7 @@ def orchestrator_function(context: df.DurableOrchestrationContext):
     else:
         filter_by_time = int(
             (datetime.now(timezone.utc) - timedelta(minutes=export_schedule_minutes)).timestamp())
-    logging.info('filter by time')
-    logging.info(filter_by_time)
+    logging.info('filter by time: %d', filter_by_time)
 
     stats_store = ExportsTableStore(connection_string, stats_table_name)
 

--- a/Solutions/TenableIO/Data Connectors/TenableProcessAssetChunkFromQueue/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableProcessAssetChunkFromQueue/__init__.py
@@ -1,13 +1,12 @@
 import json
 import logging
 import os
-from datetime import datetime
 
 import azure.functions as func
 
 from ..exports_store import ExportsTableStore, ExportsTableNames
 from ..azure_sentinel import AzureSentinel
-from ..tenable_helper import TenableIO, TenableStatus
+from ..tenable_helper import TenableIO, TenableStatus, TenableChunkPartitioner
 from tenable.errors import APIError
 
 connection_string = os.environ['AzureWebJobsStorage']
@@ -45,12 +44,22 @@ def main(msg: func.QueueMessage) -> None:
                 logging.info(
                     f'received a response from assets/{export_job_id}/chunks/{chunk_id}')
 
-                # Send to Azure Sentinel here
-                az_sentienl = AzureSentinel(
-                    workspace_id, workspace_key, log_type, log_analytics_uri)
-                az_code = az_sentienl.post_data(json.dumps(chunk))
-                logging.warn(
-                    f'Azure Sentinel reports the following status code: {az_code}')
+                # limiting individual chunk uploaded to sentinel to be < 30 MB size.
+                sub_chunks = TenableChunkPartitioner.partition_chunks_into_30MB_sub_chunks(chunk)
+
+                for sub_chunk in sub_chunks:
+                    serialized_sub_chunk = json.dumps(sub_chunk)
+
+                    logging.info('Uploading sub-chunk with size: %d', len(serialized_sub_chunk))
+
+                    # Send to Azure Sentinel here
+                    az_sentienl = AzureSentinel(
+                        workspace_id, workspace_key, log_type, log_analytics_uri)
+
+                    az_code = az_sentienl.post_data(serialized_sub_chunk)
+
+                    logging.warn(
+                        f'Azure Sentinel reports the following status code: {az_code}')
 
                 assets_table.update_if_found(export_job_id, str(chunk_id), {
                     'jobStatus': TenableStatus.finished.value

--- a/Solutions/TenableIO/Data Connectors/TenableProcessAssetChunkFromQueue/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableProcessAssetChunkFromQueue/__init__.py
@@ -53,12 +53,12 @@ def main(msg: func.QueueMessage) -> None:
                     logging.info('Uploading sub-chunk with size: %d', len(serialized_sub_chunk))
 
                     # Send to Azure Sentinel here
-                    az_sentienl = AzureSentinel(
+                    az_sentinel = AzureSentinel(
                         workspace_id, workspace_key, log_type, log_analytics_uri)
 
-                    az_code = az_sentienl.post_data(serialized_sub_chunk)
+                    az_code = az_sentinel.post_data(serialized_sub_chunk)
 
-                    logging.warn(
+                    logging.warning(
                         f'Azure Sentinel reports the following status code: {az_code}')
 
                 assets_table.update_if_found(export_job_id, str(chunk_id), {

--- a/Solutions/TenableIO/Data Connectors/TenableProcessVulnChunkFromQueue/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableProcessVulnChunkFromQueue/__init__.py
@@ -56,12 +56,12 @@ def main(msg: func.QueueMessage) -> None:
                     logging.info('Uploading sub-chunk with size: %d', len(serialized_sub_chunk))
 
                     # Send to Azure Sentinel here
-                    az_sentienl = AzureSentinel(
+                    az_sentinel = AzureSentinel(
                         workspace_id, workspace_key, log_type, log_analytics_uri)
 
-                    az_code = az_sentienl.post_data(serialized_sub_chunk)
+                    az_code = az_sentinel.post_data(serialized_sub_chunk)
 
-                    logging.warn(
+                    logging.warning(
                         f'Azure Sentinel reports the following status code: {az_code}')
 
                 vuln_table.update_if_found(export_job_id, str(chunk_id), {

--- a/Solutions/TenableIO/Data Connectors/TenableProcessVulnChunkFromQueue/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableProcessVulnChunkFromQueue/__init__.py
@@ -1,12 +1,10 @@
+import os
 import json
 import logging
-import os
-
 import azure.functions as func
 
 from ..exports_store import ExportsTableStore, ExportsTableNames
-
-from ..tenable_helper import TenableIO, TenableStatus
+from ..tenable_helper import TenableIO, TenableStatus, TenableChunkPartitioner
 from ..azure_sentinel import AzureSentinel
 from tenable.errors import APIError
 
@@ -49,12 +47,22 @@ def main(msg: func.QueueMessage) -> None:
                 logging.info(
                     f'received a response from vulns/{export_job_id}/chunks/{chunk_id}')
 
-                # Send to Azure Sentinel here
-                az_sentienl = AzureSentinel(
-                    workspace_id, workspace_key, log_type, log_analytics_uri)
-                az_code = az_sentienl.post_data(json.dumps(chunk))
-                logging.warn(
-                    f'Azure Sentinel reports the following status code: {az_code}')
+                # limiting individual chunk uploaded to sentinel to be < 30 MB size.
+                sub_chunks = TenableChunkPartitioner.partition_chunks_into_30MB_sub_chunks(chunk)
+
+                for sub_chunk in sub_chunks:
+                    serialized_sub_chunk = json.dumps(sub_chunk)
+
+                    logging.info('Uploading sub-chunk with size: %d', len(serialized_sub_chunk))
+
+                    # Send to Azure Sentinel here
+                    az_sentienl = AzureSentinel(
+                        workspace_id, workspace_key, log_type, log_analytics_uri)
+
+                    az_code = az_sentienl.post_data(serialized_sub_chunk)
+
+                    logging.warn(
+                        f'Azure Sentinel reports the following status code: {az_code}')
 
                 vuln_table.update_if_found(export_job_id, str(chunk_id), {
                     'jobStatus': TenableStatus.finished.value

--- a/Solutions/TenableIO/Data Connectors/TenableStartAssetExportJob/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableStartAssetExportJob/__init__.py
@@ -8,7 +8,10 @@ def main(timestamp: int) -> object:
     tio = TenableIO()
     logging.info(
         f'requesting a new Asset Export Job from Tenable')
-    job_id = tio.exports.assets(updated_at=timestamp)
+    # limiting chunk size to contain 100 assets details. For some bigger
+    # containers, each chunk is reported to be some hundreds of MBs resulting
+    # into azure function crash due to OOM errors.
+    job_id = tio.exports.assets(updated_at=timestamp, chunk_size=100)
 
     logging.info(f'received a response from Asset Export Job request')
     logging.info(job_id)

--- a/Solutions/TenableIO/Data Connectors/TenableStartVulnExportJob/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableStartVulnExportJob/__init__.py
@@ -8,7 +8,7 @@ def main(timestamp: int) -> object:
     tio = TenableIO()
     logging.info(
         f'requesting a new Vuln Export Job from Tenable')
-    # limiting number of assets to 100. For some bigger containers, 
+    # limiting number of assets to 50. For some bigger containers, 
     # each chunk is reported to be some hundreds of MBs resulting
     # into azure function crash due to OOM errors.
     job_id = tio.exports.vulns(last_found=timestamp, num_assets=50)

--- a/Solutions/TenableIO/Data Connectors/TenableStartVulnExportJob/__init__.py
+++ b/Solutions/TenableIO/Data Connectors/TenableStartVulnExportJob/__init__.py
@@ -8,7 +8,10 @@ def main(timestamp: int) -> object:
     tio = TenableIO()
     logging.info(
         f'requesting a new Vuln Export Job from Tenable')
-    job_id = tio.exports.vulns(updated_at=timestamp)
+    # limiting number of assets to 100. For some bigger containers, 
+    # each chunk is reported to be some hundreds of MBs resulting
+    # into azure function crash due to OOM errors.
+    job_id = tio.exports.vulns(last_found=timestamp, num_assets=50)
 
     logging.info(f'received a response from Vuln Export Job request')
     logging.info(job_id)

--- a/Solutions/TenableIO/Data Connectors/tenable_helper.py
+++ b/Solutions/TenableIO/Data Connectors/tenable_helper.py
@@ -1,7 +1,13 @@
+import os
+import logging
+import json
+
 from tenable.io import TenableIO as BaseIO
 from tenable.io.exports import ExportsAPI
 from enum import Enum
-import os
+from queue import Queue
+from typing import List, Dict
+
 
 class ExportsAPIExtended(ExportsAPI):
     def vulns(self, **kwargs) -> str:
@@ -45,3 +51,54 @@ class TenableStatus(Enum):
 class TenableExportType(Enum):
     asset = 'ASSET_EXPORT_JOB'
     vuln = 'VULN_EXPORT_JOB'
+
+
+class TenableChunkPartitioner:
+    KB = 1024
+    MB = KB * KB
+    MAX_UPLOAD_SIZE = 30 * MB
+    MAX_REQUEST_HEADERS_OVERHEAD = 2 * MB
+
+    @staticmethod
+    def partition_chunks_into_30MB_sub_chunks(inputChunk: List[Dict]) -> List[List[Dict]]:
+        '''
+        This method divides export chunks received from Tenable.io response, into multiple sub-chunks
+        such that each sub-chunk is <= 30MB.
+        
+        This is necessary as per https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#data-limits.
+
+        Parameters:
+            inputChunk (List[Dict]): List containing vuln/assets objects in chunk.
+
+        Returns:
+            List[List[Dict]] -> List containing one or more sub-chunks created out of input chunk.
+        '''
+        queue = Queue()
+        output_sub_chunks = []
+
+        queue.put_nowait(inputChunk)
+
+        while queue.qsize() > 0:
+            sub_chunk = queue.get_nowait()
+            sub_chunk_size = len(json.dumps(sub_chunk))
+            sub_chunk_length = len(sub_chunk)
+
+            logging.info('Fetched sub-chunk from queue with %d elements & %d size(in bytes)', sub_chunk_length, sub_chunk_size)
+
+            if (sub_chunk_size + TenableChunkPartitioner.MAX_REQUEST_HEADERS_OVERHEAD) <= TenableChunkPartitioner.MAX_UPLOAD_SIZE:
+                output_sub_chunks.append(sub_chunk)
+
+                logging.info('Added sub-chunk %d elements & %d size(in bytes) to list of output chunks.', sub_chunk_length, sub_chunk_size)
+            else:
+                divider_index = int(sub_chunk_length / 2)
+                left_chunk = sub_chunk[:divider_index]
+                right_chunk = sub_chunk[divider_index:]
+
+                queue.put_nowait(left_chunk)
+                queue.put_nowait(right_chunk)
+
+                logging.info('Re-enqueued 2 sub-chunks with elements: %d <-> %d', len(left_chunk), len(right_chunk))
+
+        logging.info('Created %d output sub-chunks.', len(output_sub_chunks))
+
+        return output_sub_chunks

--- a/Solutions/TenableIO/Data Connectors/tenable_helper.py
+++ b/Solutions/TenableIO/Data Connectors/tenable_helper.py
@@ -65,7 +65,8 @@ class TenableChunkPartitioner:
         This method divides export chunks received from Tenable.io response, into multiple sub-chunks
         such that each sub-chunk is <= 30MB.
         
-        This is necessary as per https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#data-limits.
+        This is necessary as per
+        https://docs.microsoft.com/en-us/azure/azure-monitor/logs/data-collector-api#data-limits.
 
         Parameters:
             inputChunk (List[Dict]): List containing vuln/assets objects in chunk.
@@ -83,12 +84,20 @@ class TenableChunkPartitioner:
             sub_chunk_size = len(json.dumps(sub_chunk))
             sub_chunk_length = len(sub_chunk)
 
-            logging.info('Fetched sub-chunk from queue with %d elements & %d size(in bytes)', sub_chunk_length, sub_chunk_size)
+            logging.info(
+                'Fetched sub-chunk from queue with %d elements & %d size(in bytes)',
+                sub_chunk_length, sub_chunk_size
+            )
 
-            if (sub_chunk_size + TenableChunkPartitioner.MAX_REQUEST_HEADERS_OVERHEAD) <= TenableChunkPartitioner.MAX_UPLOAD_SIZE:
+            request_size = sub_chunk_size + TenableChunkPartitioner.MAX_REQUEST_HEADERS_OVERHEAD
+            if request_size <= TenableChunkPartitioner.MAX_UPLOAD_SIZE:
                 output_sub_chunks.append(sub_chunk)
 
-                logging.info('Added sub-chunk %d elements & %d size(in bytes) to list of output chunks.', sub_chunk_length, sub_chunk_size)
+                logging.info(
+                    'Added sub-chunk %d elements & %d size(in bytes) to list of output chunks.',
+                    sub_chunk_length,
+                    sub_chunk_size
+                )
             else:
                 divider_index = int(sub_chunk_length / 2)
                 left_chunk = sub_chunk[:divider_index]


### PR DESCRIPTION
Required items, please complete
   
   Change(s):
   - Put limit on tenable.io assets and vulns exports chunk size.
   - Divides individual export chunk into sub-chunk to enforce 30 MB size of each sub-chunk.

   Reason for Change(s):
   - Some containers with huge amount of data, were returning export chunks in few hundreds of MBs(overall export size more than few GBs). 
   - It resulted into 1) Taking too much time to download export chunk in activity function, 2) OOM result causing function app to crash, and 3) Chunk failing to get uploaded to sentinel(due to 30 MB limit).

   Version Updated:
   - N/A

   Testing Completed:
   - Yes

   Checked that the validations are passing and have addressed any issues that are present:
   - Yes
